### PR TITLE
[CODEQUALITY]: biguint tests: less magic numbers; adc/sbc tests rely …

### DIFF
--- a/tests/biguint128_add_test.c
+++ b/tests/biguint128_add_test.c
@@ -30,6 +30,20 @@ const CStr hex_samples[][3] = {
 };
 int hex_sample_len = ARRAYSIZE(hex_samples);
 
+static void fprintf_biguint128_xxc_testresult(FILE *out, BigUInt128 *op0, BigUInt128 *op1, buint_bool op2, BigUInt128 *expected, buint_bool exp2, BigUInt128 *actual, buint_bool actual2, const char *funname) {
+ ArgType argt[] = {BUINT_XROREF, BUINT_XROREF, BUINT_TBOOL};
+ GenArgU values[] = {
+  {.x = *op0},
+  {.x = *op1},
+  {.b = op2},
+  {.x = *expected},
+  {.b = exp2},
+  {.x = *actual},
+  {.b = actual2}
+ };
+ fprintf_biguint128_genfun0_testresult(out, funname, values, values + 5, values + 3, 3, argt, 2, argt + 1, FMT_HEX);
+}
+
 bool test_adcsbc_all() {
  bool fail=false;
 
@@ -37,7 +51,7 @@ bool test_adcsbc_all() {
   biguint128_adc_replace,
   biguint128_sbc_replace
  };
- const char *op[]={"+'","-'"};
+ const char *op[]={"adc","sbc"};
 
  AdcSbcTestV tests[]= {
   {max, zero, 0, 0, max, 0},
@@ -63,10 +77,9 @@ bool test_adcsbc_all() {
   buint_bool act_c=tests[i].c;
   fun[tests[i].sbc](&act_res, &tests[i].a, &tests[i].b, &act_c);
   if (!biguint128_eq(&tests[i].exp_res, &act_res) || tests[i].exp_c!=act_c) {
-   fprintf_biguint128_binop_testresult(
-           stderr, &tests[i].a, &tests[i].b, &tests[i].exp_res, &act_res, op[tests[i].sbc]);
-   fprintf(stderr,"carry expected: %u, actual: %u\n", tests[i].exp_c, act_c);
-   fail = 1;
+   fprintf_biguint128_xxc_testresult(
+           stderr, &tests[i].a, &tests[i].b, tests[i].c, &tests[i].exp_res, tests[i].exp_c, &act_res, act_c, op[tests[i].sbc]);
+   fail |= 1;
   }
  }
 

--- a/tests/biguint128_bit_test.c
+++ b/tests/biguint128_bit_test.c
@@ -12,44 +12,40 @@
 
 // Logical bitwise test data
 // A, B, A|B, A&B, A^B
-#define LSAMPLE_LEN 5U
-const CStr lsamples[][LSAMPLE_LEN] = {
+#define LSAMPLE_W 5U
+const CStr lsamples[][LSAMPLE_W] = {
  {STR("FF0"), STR("F00F"), STR("FFFF"), STR("0"), STR("FFFF")},
  {STR("FFF"), STR("F00F"), STR("FFFF"), STR("F"), STR("FFF0")},
  {STR("3FFFFFFFFFFFFFFFF"), STR("5FFFFFFFFFFFFFFFF"), STR("7FFFFFFFFFFFFFFFF"), STR("1FFFFFFFFFFFFFFFF"), STR("60000000000000000")}
 };
-const unsigned int lsamples_n = sizeof (lsamples) / sizeof (lsamples[0]);
+const unsigned int lsamples_n = ARRAYSIZE(lsamples);
 
 // Shift test data
 
-#define SHSAMPLE_LEN 4U
+#define SHSAMPLE_W 4U
 typedef struct {
  buint_size_t bits_limit;
- CStr dat[SHSAMPLE_LEN];
+ CStr dat[SHSAMPLE_W];
 } ShiftSample;
 const ShiftSample shsamples[] = {
+ {-1,
+  {STR("FFFFFFFF000000000000"), STR("0"), STR("FFFFFFFF000000000000"), STR("FFFFFFFF000000000000")}},
  {-1,
   {STR("1"), STR("1"), STR("2"), STR("0")}},
  {-1,
   {STR("1"), STR("2"), STR("4"), STR("0")}},
  {-1,
   {STR("12345678"), STR("4"), STR("123456780"), STR("1234567")}},
+ {-1,
+  {STR("FFFFFFFF000000000000"), STR("8"), STR("FFFFFFFF00000000000000"), STR("FFFFFFFF0000000000")}},
+ {-1,
+  {STR("FFFFFFFF000000000000"), STR("32"), STR("FFFFFFFF00000000000000000000"), STR("FFFFFFFF0000")}},
  {127+1,
   {STR("A5A5A5A5A5A5A5A5A5A5A5A5A5A5A5A5"), STR("127"), STR("80000000000000000000000000000000"), STR("1")}},
  {-1,
   {STR("5A5A5A5A5A5A5A5A5A5A5A5A5A5A5A5A5"), STR("1"), STR("B4B4B4B4B4B4B4B4B4B4B4B4B4B4B4B4A"), STR("2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2D2")}}
 };
-const unsigned int shsamples_n = sizeof (shsamples) / sizeof (shsamples[0]);
-
-static void print_fun1_error(const char *expr, const BigUInt128 *a, buint_size_t expected, buint_size_t actual) {
- char abuf[BIGUINT_BITS/4 + 1];
- abuf[biguint128_print_hex(a, abuf, BIGUINT_BITS/4)]=0;
- fprintf(stderr, "%s(%s) -- expected: %"PRIbuint_size_t", actual: %"PRIbuint_size_t"\n", expr, abuf, expected, actual);
-}
-
-static void print_assign_ptr_error(const char *expr, const BigUInt128 *expected, const BigUInt128 *actual) {
- fprintf(stderr, "%s does not preserve pointer -- input parameter: %p, return value: %p\n", expr, (void*)expected, (void*)actual);
-}
+const unsigned int shsamples_n = ARRAYSIZE(shsamples);
 
 bool test_gen_write_get0(bool clr) {
  bool fail = false;
@@ -122,91 +118,23 @@ bool test_gen_write_get0(bool clr) {
  return !fail;
 }
 
-
-// checks: rol(x,a) == or(shl(x,a), shr(x,128-a))
-bool test_shiftrot0() {
- bool fail=false;
-
- const CStr val_a[]={
-  STR("12345678"),
-  STR("123456789ABCDEF0"),
-  STR("1223334444555556666667777777"),
-  STR("123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0"),
-  STR("122333444455555666666777777788888888999999999AAAAAAAAAABBBBBBBBB")
- };
- size_t val_len=sizeof(val_a)/sizeof(val_a[0]);
- const buint_size_t sh_a[]={0,1,2,4,7,16,31,63,64,127,128,129,255,256};
- size_t sh_len=sizeof(sh_a)/sizeof(sh_a[0]);
-
- for (size_t vi= 0; vi < val_len; ++vi) {
-  for (size_t si= 0; si < sh_len; ++si) {
-   BigUInt128 a;
-   if (!read_cstr_biguint128(&a, &val_a[vi], FMT_HEX)) continue;
-   BigUInt128 act_rol= biguint128_rol(&a, sh_a[si]);
-   BigUInt128 act_ror= biguint128_ror(&a, sh_a[si]);
-
-   BigUInt128 res_shl= biguint128_shl(&a, sh_a[si] % BIGUINT_BITS);
-   BigUInt128 res_shl_oflow= biguint128_shr(&a, (BIGUINT_BITS - sh_a[si]) % BIGUINT_BITS);
-   BigUInt128 exp_rol= biguint128_or(&res_shl, &res_shl_oflow);
-
-   BigUInt128 res_shr= biguint128_shr(&a, sh_a[si] % BIGUINT_BITS);
-   BigUInt128 res_shr_uflow= biguint128_shl(&a, (BIGUINT_BITS - sh_a[si]) % BIGUINT_BITS);
-   BigUInt128 exp_ror= biguint128_or(&res_shr, &res_shr_uflow);
-   BigUInt128 res_shra= biguint128_ctor_copy(&a);
-   BigUInt128 *res2_shra= biguint128_shr_assign(&res_shra, sh_a[si] % BIGUINT_BITS);
-
-   if (sh_a[si]<UINT_BITS) {
-    BigUInt128 res_shlt = biguint128_ctor_copy(&a);
-    biguint128_shl_tiny(&res_shlt, sh_a[si]);
-
-    BigUInt128 res_shrt = biguint128_ctor_copy(&a);
-    biguint128_shr_tiny(&res_shrt, sh_a[si]);
-
-    if (!biguint128_eq(&res_shl, &res_shlt)) {
-     fprint_funres_buint128_x_bsz_buint128(stderr, "shlt", &a, sh_a[si], &res_shl, &res_shlt);
-     fail=true;
-    }
-
-    if (!biguint128_eq(&res_shr, &res_shrt)) {
-     fprint_funres_buint128_x_bsz_buint128(stderr, "shrt", &a, sh_a[si], &res_shr, &res_shrt);
-     fail=true;
-    }
-   }
-
-   if (!biguint128_eq(&exp_rol, &act_rol)) {
-    fprint_funres_buint128_x_bsz_buint128(stderr, "rol", &a, sh_a[si], & exp_rol, &act_rol);
-    fail=true;
-   }
-   if (!biguint128_eq(&exp_ror, &act_ror)) {
-    fprint_funres_buint128_x_bsz_buint128(stderr, "ror", &a, sh_a[si], & exp_ror, &act_ror);
-    fail=true;
-   }
-
-   if (!biguint128_eq(&res_shra, &res_shr)) {
-    fprint_funres_buint128_x_bsz_buint128(stderr, "shra (param)", &a, sh_a[si], &res_shr, &res_shra);
-    fail=true;
-   }
-
-   if (&res_shra != res2_shra) {
-    print_assign_ptr_error("shr_a", &res_shra, res2_shra);
-    fail=true;
-   }
-
-  }
- }
-
- return !fail;
-}
-
 static bool check_lzx(const BigUInt128 *a, buint_size_t exp_cell, buint_size_t res_cell, buint_size_t exp_bit, buint_size_t res_bit) {
  bool pass = true;
+ ArgType paramt = BUINT_XROREF;
+ ArgType rest = BUINT_TSIZE;
+ GenArgU arg = {.x=*a};
+ GenArgU exp_c = {.sz = exp_cell};
+ GenArgU act_c = {.sz = res_cell};
+ GenArgU exp_b = {.sz = exp_bit};
+ GenArgU act_b = {.sz = res_bit};
+
  if (exp_cell != res_cell) {
-  print_fun1_error("lzc", a, exp_cell, res_cell);
+  fprintf_biguint128_genfun0_testresult(stderr, "lzc", &arg, &act_c, &exp_c, 1, &paramt, 1, &rest, FMT_HEX);
   pass = false;
  }
 
  if (exp_bit != res_bit) {
-  print_fun1_error("lzb", a, exp_bit, res_bit);
+  fprintf_biguint128_genfun0_testresult(stderr, "lzb", &arg, &act_b, &exp_b, 1, &paramt, 1, &rest, FMT_HEX);
   pass = false;
  }
  return pass;
@@ -231,7 +159,7 @@ bool test_lzx_single_bit() {
  return pass;
 }
 
-bool test_lzx_single_bit0() {
+bool test_lzx_no_bits() {
  BigUInt128 a = biguint128_ctor_default();
 
  buint_size_t res_cell = biguint128_lzc(&a);
@@ -240,6 +168,7 @@ bool test_lzx_single_bit0() {
  return check_lzx(&a, 0, res_cell, 0, res_bit);
 }
 
+// composition
 static void create_rotated_(CStr *dst, char *buf, unsigned int buflen, const CStr src, buint_size_t shl) {
  BigUInt128 a = biguint128_ctor_hexcstream(src.str, src.len);
  BigUInt128 ahi = biguint128_shl(&a, shl);
@@ -282,22 +211,22 @@ int main() {
  unsigned int xor_params[]={0,1,4};
  unsigned int id_params[]={0,0};
 
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, and_params,XBFUN0(biguint128_and), "and", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, or_params, XBFUN0(biguint128_or), "or", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, xor_params, XBFUN0(biguint128_xor), "xor", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, or_params, XBFUN0(nandn_), "nandofnots", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, and_params,XBFUN0(biguint128_and), "and", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, or_params, XBFUN0(biguint128_or), "or", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, xor_params, XBFUN0(biguint128_xor), "xor", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, or_params, XBFUN0(nandn_), "nandofnots", NULL) == 0);
 
 #ifndef WITHOUT_PASS_BY_VALUE_FUNCTIONS
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, and_params, XBFUN0V(biguint128_andv), "andv", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, or_params, XBFUN0V(biguint128_orv), "orv", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, xor_params, XBFUN0V(biguint128_xorv), "xorv", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, or_params, XBFUN0V(nandnv_), "nandofnotsv", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, and_params, XBFUN0V(biguint128_andv), "andv", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, or_params, XBFUN0V(biguint128_orv), "orv", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, xor_params, XBFUN0V(biguint128_xorv), "xorv", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, or_params, XBFUN0V(nandnv_), "nandofnotsv", NULL) == 0);
 #endif
 
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, and_params, XBFUN0A(biguint128_and_assign), "and_assign", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, or_params, XBFUN0A(biguint128_or_assign), "or_assign", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, xor_params, XBFUN0A(biguint128_xor_assign), "xor_assign", NULL) == 0);
- assert(test_genfun(&lsamples[0][0], LSAMPLE_LEN, lsamples_n, FMT_HEX, id_params, XUFUN0A(notnot_asg_), "notnot_assign", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, and_params, XBFUN0A(biguint128_and_assign), "and_assign", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, or_params, XBFUN0A(biguint128_or_assign), "or_assign", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, xor_params, XBFUN0A(biguint128_xor_assign), "xor_assign", NULL) == 0);
+ assert(test_genfun(&lsamples[0][0], LSAMPLE_W, lsamples_n, FMT_HEX, id_params, XUFUN0A(notnot_asg_), "notnot_assign", NULL) == 0);
 
 // assert(test_and_or_not0());
  assert(test_gen_write_get0(false));
@@ -309,11 +238,12 @@ int main() {
  unsigned int rol_params[] = {0, 1, 4};
  unsigned int ror_params[] = {0, 1, 5};
 
- CStr shxsamples[shsamples_n][6];
+ const unsigned int SHXSAMPLES_W = 6U;
+ CStr shxsamples[shsamples_n][SHXSAMPLES_W];
  char rolbuffer[shsamples_n][HEX_BIGUINTLEN+1];
  char rorbuffer[shsamples_n][HEX_BIGUINTLEN+1];
  for (unsigned int i = 0; i < shsamples_n; ++i) {
-  for (unsigned int j = 0; j < SHSAMPLE_LEN; ++j) {
+  for (unsigned int j = 0; j < SHSAMPLE_W; ++j) {
    shxsamples[i][j] = shsamples[i].dat[j];
   }
   if (shsamples[i].bits_limit < BIGUINT_BITS) { // disable inputs if test suite exceeds size limit
@@ -323,24 +253,22 @@ int main() {
   create_rotated_(&shxsamples[i][4], rolbuffer[i], HEX_BIGUINTLEN, shxsamples[i][0], shift);
   create_rotated_(&shxsamples[i][5], rorbuffer[i], HEX_BIGUINTLEN, shxsamples[i][0], BIGUINT_BITS - shift);
  }
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shl_params, XBFUN1(biguint128_shl), "shl", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shr_params, XBFUN1(biguint128_shr), "shr", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, rol_params, XBFUN1(biguint128_rol), "rol", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, ror_params, XBFUN1(biguint128_ror), "ror", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shr_params, XBFUN1A(biguint128_shr_assign), "shr_assign", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shl_params, XBFUN1A(biguint128_shl_tiny), "shl_tiny", check_tiny_) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shr_params, XBFUN1A(biguint128_shr_tiny), "shr_tiny", check_tiny_) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shl_params, XBFUN1(biguint128_shl), "shl", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shr_params, XBFUN1(biguint128_shr), "shr", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, rol_params, XBFUN1(biguint128_rol), "rol", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, ror_params, XBFUN1(biguint128_ror), "ror", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shr_params, XBFUN1A(biguint128_shr_assign), "shr_assign", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shl_params, XBFUN1A(biguint128_shl_tiny), "shl_tiny", check_tiny_) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shr_params, XBFUN1A(biguint128_shr_tiny), "shr_tiny", check_tiny_) == 0);
 
 #ifndef WITHOUT_PASS_BY_VALUE_FUNCTIONS
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shl_params, XBFUN1V(biguint128_shlv), "shlv", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, shr_params, XBFUN1V(biguint128_shrv), "shrv", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, rol_params, XBFUN1V(biguint128_rolv), "rolv", NULL) == 0);
- assert(test_genfun(&shxsamples[0][0], 6, shsamples_n, FMT_HEX, ror_params, XBFUN1V(biguint128_rorv), "rorv", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shl_params, XBFUN1V(biguint128_shlv), "shlv", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, shr_params, XBFUN1V(biguint128_shrv), "shrv", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, rol_params, XBFUN1V(biguint128_rolv), "rolv", NULL) == 0);
+ assert(test_genfun(&shxsamples[0][0], SHXSAMPLES_W, shsamples_n, FMT_HEX, ror_params, XBFUN1V(biguint128_rorv), "rorv", NULL) == 0);
 #endif
 
- assert(test_shiftrot0());
-
  assert(test_lzx_single_bit());
- assert(test_lzx_single_bit0());
+ assert(test_lzx_no_bits());
  return 0;
 }

--- a/tests/biguint128_eq_test.c
+++ b/tests/biguint128_eq_test.c
@@ -3,8 +3,9 @@
 #include "test_common128.h"
 #include <assert.h>
 
+#define SAMPLEX_W 5U
 // a, b, lt, ilt, eq
-CStr samplex[][5]= {
+CStr samplex[][SAMPLEX_W]= {
  {STR("0"), STR("0"), STR("0"), STR("0"), STR("1")},
  {STR("1"), STR("0"), STR("0"), STR("0"), STR("0")},
  {STR("-1"), STR("0"), STR("0"), STR("1"), STR("0")},
@@ -17,8 +18,9 @@ CStr samplex[][5]= {
  {STR("1"), STR("1"), STR("0"), STR("0"), STR("1")}
 };
 
+#define SAMPLEZ_W 3U
 // a, ltz, eqz
-CStr samplez[][3]={
+CStr samplez[][SAMPLEZ_W]={
  {STR("4294967296"), STR("0"), STR("0")},
  {STR("1234567890"), STR("0"), STR("0")},
  {STR("12345678901234567890"), STR("0"), STR("0")},
@@ -37,26 +39,25 @@ int main() {
  unsigned int ilt_params[] = {0, 1, 3};
  unsigned int eq_params[] = {0, 1, 4};
 
- assert(test_genfun(&samplex[0][0], 5, ARRAYSIZE(samplex), FMT_SDEC, lt_params, XBREL0(biguint128_lt), "lt", NULL) == 0);
- assert(test_genfun(&samplex[0][0], 5, ARRAYSIZE(samplex), FMT_SDEC, ilt_params, XBREL0(bigint128_lt), "ilt", NULL) == 0);
- assert(test_genfun(&samplex[0][0], 5, ARRAYSIZE(samplex), FMT_SDEC, eq_params, XBREL0(biguint128_eq), "eq", NULL) == 0);
+ assert(test_genfun(&samplex[0][0], SAMPLEX_W, ARRAYSIZE(samplex), FMT_SDEC, lt_params, XBREL0(biguint128_lt), "lt", NULL) == 0);
+ assert(test_genfun(&samplex[0][0], SAMPLEX_W, ARRAYSIZE(samplex), FMT_SDEC, ilt_params, XBREL0(bigint128_lt), "ilt", NULL) == 0);
+ assert(test_genfun(&samplex[0][0], SAMPLEX_W, ARRAYSIZE(samplex), FMT_SDEC, eq_params, XBREL0(biguint128_eq), "eq", NULL) == 0);
 
 
  unsigned int ltz_params[] = {0, 1};
  unsigned int eqz_params[] = {0, 2};
 
- assert(test_genfun(&samplez[0][0], 3, samplez_len, FMT_SDEC, ltz_params, XUREL0(bigint128_ltz), "ltz", NULL) == 0);
- assert(test_genfun(&samplez[0][0], 3, samplez_len, FMT_SDEC, eqz_params, XUREL0(biguint128_eqz), "eqz", NULL) == 0);
+ assert(test_genfun(&samplez[0][0], SAMPLEZ_W, samplez_len, FMT_SDEC, ltz_params, XUREL0(bigint128_ltz), "ltz", NULL) == 0);
+ assert(test_genfun(&samplez[0][0], SAMPLEZ_W, samplez_len, FMT_SDEC, eqz_params, XUREL0(biguint128_eqz), "eqz", NULL) == 0);
 
 #ifndef WITHOUT_PASS_BY_VALUE_FUNCTIONS
- assert(test_genfun(&samplex[0][0], 5, ARRAYSIZE(samplex), FMT_SDEC, lt_params, XBREL0V(biguint128_ltv), "ltv", NULL) == 0);
- assert(test_genfun(&samplex[0][0], 5, ARRAYSIZE(samplex), FMT_SDEC, ilt_params, XBREL0V(bigint128_ltv), "iltv", NULL) == 0);
- assert(test_genfun(&samplex[0][0], 5, ARRAYSIZE(samplex), FMT_SDEC, eq_params, XBREL0V(biguint128_eqv), "eqv", NULL) == 0);
+ assert(test_genfun(&samplex[0][0], SAMPLEX_W, ARRAYSIZE(samplex), FMT_SDEC, lt_params, XBREL0V(biguint128_ltv), "ltv", NULL) == 0);
+ assert(test_genfun(&samplex[0][0], SAMPLEX_W, ARRAYSIZE(samplex), FMT_SDEC, ilt_params, XBREL0V(bigint128_ltv), "iltv", NULL) == 0);
+ assert(test_genfun(&samplex[0][0], SAMPLEX_W, ARRAYSIZE(samplex), FMT_SDEC, eq_params, XBREL0V(biguint128_eqv), "eqv", NULL) == 0);
 
- assert(test_genfun(&samplez[0][0], 3, samplez_len, FMT_SDEC, ltz_params, XUREL0V(bigint128_ltzv), "ltzv", NULL) == 0);
- assert(test_genfun(&samplez[0][0], 3, samplez_len, FMT_SDEC, eqz_params, XUREL0V(biguint128_eqzv), "eqzv", NULL) == 0);
+ assert(test_genfun(&samplez[0][0], SAMPLEZ_W, samplez_len, FMT_SDEC, ltz_params, XUREL0V(bigint128_ltzv), "ltzv", NULL) == 0);
+ assert(test_genfun(&samplez[0][0], SAMPLEZ_W, samplez_len, FMT_SDEC, eqz_params, XUREL0V(biguint128_eqzv), "eqzv", NULL) == 0);
 #endif
 
  return 0;
 }
-

--- a/tests/test_common128.c
+++ b/tests/test_common128.c
@@ -124,15 +124,6 @@ static inline void print_gennums(FILE *out, const GenArgU *nums, unsigned int nu
  }
 }
 
-void fprintf_biguint128_binop_testresult(FILE *out, BigUInt128 *op0, BigUInt128 *op1, BigUInt128 *expected, BigUInt128 *actual, const char *op_str) {
- char buffer[4][HEX_BIGUINTLEN + 1];
- BigUInt128 * v_refs[] = {op0, op1, expected, actual};
- for (int j = 0; j < 4; ++j) {
-  buffer[j][biguint128_print_hex(v_refs[j], buffer[j], HEX_BIGUINTLEN)] = 0;
- }
- fprintf(out, "[%s %s %s] -- expected: [%s], actual [%s]\n", buffer[0], op_str, buffer[1], buffer[2], buffer[3]);
-}
-
 void fprintf_biguint128_genfun0_testresult(FILE *out, const char *funname, GenArgU *values, GenArgU *result, GenArgU *expected, unsigned int arg_n, ArgType *argt, unsigned int res_n, ArgType *rest, Format fmt) {
    fprintf(out, "%s(", funname);
    print_gennums(out, values, arg_n, argt, fmt);

--- a/tests/test_common128.h
+++ b/tests/test_common128.h
@@ -149,9 +149,6 @@ void fprint_funres_buint128_x_bsz_buint128(FILE *out, const char *funname, const
 void fprint_funres_buint128_x_bsz_bb(FILE *out, const char *funname, const BigUInt128 *a, buint_size_t b, buint_bool expected, buint_bool actual);
 void fprintf_biguint128_genfun0_testresult(FILE *out, const char *funname, GenArgU *values, GenArgU *result, GenArgU *expected, unsigned int arg_n, ArgType *argt, unsigned int res_n, ArgType *rest, Format fmt);
 
-void fprintf_biguint128_binop_testresult(FILE *out, BigUInt128 *op0, BigUInt128 *op1, BigUInt128 *expected, BigUInt128 *actual, const char *op_str);
-void fprintf_biguint128_unop_testresult(FILE *out, const BigUInt128 *op0, const BigUInt128 *expected, const BigUInt128 *actual, const char *op_str);
-
 int test_genfun(const CStr *samples, unsigned int sample_width, unsigned int sample_n, Format fmt, const unsigned int *param_idx, BigUInt128GenFun fun, const char *funname, ParamRelation param_valid);
 
 #endif /* TEST_COMMON128_H */


### PR DESCRIPTION
…on generic error printing function.